### PR TITLE
Change request body type to unknown

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import { Files } from 'formidable';
 
 declare module "koa" {
     interface Request extends Koa.BaseRequest {
-        body?: any;
+        body?: unknown;
         files?: Files;
     }
 }


### PR DESCRIPTION
Merged declarations should use as narrow types as possible, since they could interfere with other other libraries or application code.  I believe the `unknown` type is more appropriate here since it allows the body type to be further narrowed later on, e.g., by validation middleware.