### PR TITLE
bugfix/ add back empty object as body if content-type has no match

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,18 @@ export function koaBody(options: Partial<KoaBodyMiddlewareOptions> = {}): Middle
             patchKoa,
             patchNode,
           });
+        } else {
+          patchNodeAndKoa(
+            ctx as ContextWithBodyAndFiles,
+            {},
+            {
+              isText,
+              includeUnparsed: returnRawBody,
+              isMultipart,
+              patchKoa,
+              patchNode,
+            },
+          );
         }
       } catch (parsingError) {
         const error = throwableToError(parsingError);


### PR DESCRIPTION
add back empty object if all isJson, isText, isUrlencoded, isMultipart are falsy
fixes: https://github.com/koajs/koa-body/issues/218
## Checklist

- [ ] I have ensured my pull request is not behind the main or master branch of the original repository.
- [ ] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [ ] I have written a commit message that passes commitlint linting.
- [ ] I have ensured that my code changes pass linting tests.
- [ ] I have ensured that my code changes pass unit tests.
- [ ] I have described my pull request and the reasons for code changes along with context if necessary.
