### PR TITLE
Add 'setEmptyBody' configuration option and functionality, to allow s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,12 @@ Request Body: {"declaration":{"attributes":{"version":"1.0"}},"elements":[{"type
 - `text` **{Boolean}** Parse text bodies, such as XML, default `true`
 - `json` **{Boolean}** Parse JSON bodies, default `true`
 - `jsonStrict` **{Boolean}** Toggles co-body strict mode; if set to true - only parses arrays or objects, default `true`
-- `includeUnparsed` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for form encoded and JSON requests the raw, unparsed request body will be attached to `ctx.request.body` using a `Symbol` ([see details](#a-note-about-unparsed-request-bodies)), default `false`
+- `includeUnparsed` **{Boolean}** Toggles co-body returnRawBody option; if set to true, for form encoded and JSON requests the raw, unparsed request body will be attached to
+- `ctx.request.body` using a `Symbol` ([see details](#a-note-about-unparsed-request-bodies)), default `false`
 - `formidable` **{Object}** Options to pass to the formidable multipart parser
 - `onError` **{Function}** Custom error handle, if throw an error, you can customize the response - onError(error, context), default will throw
 - `parsedMethods` **{String[]}** Declares the HTTP methods where bodies will be parsed, default `['POST', 'PUT', 'PATCH']`. Replaces `strict` option.
+- `setEmptyBody` **{Boolean}** When the `content-type` header value does not match a supported type, if an empty body value should be set, default `false`
 
 ## A note about `parsedMethods`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ export function koaBody(options: Partial<KoaBodyMiddlewareOptions> = {}): Middle
       onError,
       patchNode,
       patchKoa,
+      setEmptyBody,
     } = optionsToUse;
     // only parse the body on specifically chosen methods
     if (validatedOptions.parsedMethods.includes(toHttpMethod(ctx.method.toUpperCase()))) {
@@ -94,6 +95,18 @@ export function koaBody(options: Partial<KoaBodyMiddlewareOptions> = {}): Middle
             patchKoa,
             patchNode,
           });
+        } else if (setEmptyBody) {
+          patchNodeAndKoa(
+            ctx as ContextWithBodyAndFiles,
+            {},
+            {
+              isText,
+              includeUnparsed: returnRawBody,
+              isMultipart,
+              patchKoa,
+              patchNode,
+            },
+          );
         }
       } catch (parsingError) {
         const error = throwableToError(parsingError);

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,11 @@ export const KoaBodyMiddlewareOptionsSchema = z.object({
     .array(HttpMethod)
     .optional()
     .default([HttpMethodEnum.POST, HttpMethodEnum.PUT, HttpMethodEnum.PATCH]),
+
+  /**
+   * {Boolean} When content-type does not match a supported type, if an empty body value should be set, default false
+   */
+  setEmptyBody: z.boolean().optional().default(false),
 });
 
 export type KoaBodyDirectOptions = z.infer<typeof KoaBodyMiddlewareOptionsSchema>;


### PR DESCRIPTION
…etting an empty body when no supported content-type is provided

This addresses https://github.com/koajs/koa-body/issues/218 and superseeds https://github.com/koajs/koa-body/pull/219

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [ ] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
