### PR TITLE
Update formidable dependency to 2.x to 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
   ],
   "dependencies": {
     "@types/co-body": "^6.1.0",
-    "@types/formidable": "^2.0.5",
+    "@types/formidable": "^3.4.5",
     "@types/koa": "^2.13.5",
     "co-body": "^6.1.0",
-    "formidable": "^2.0.1",
+    "formidable": "^3.5.4",
     "zod": "^3.19.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR is about to fix the audit issue related to formidable vulnerability fixed in >= 3.5.3

low: Formidable relies on hexoid to prevent guessing of filenames for untrusted executable content
Package: formidable
Patched in: >=3.5.3
Dependency of: koa-body
Path: koa-body > formidable
More info: https://www.npmjs.com/advisories/1104069

When migrating from Formidable 2.0.1 to 3.5.4, the types of the Fields and Files have changed.

Formidable 2.0.1

    interface Fields {
        [field: string]: string | string[];
    }
    interface Files {
        [file: string]: File | File[];
    }

Formidable 3.5.4

    type Fields<T extends string = string> = {
        readonly [Prop in T]?: string[];
    };
    type Files<U extends string = string> = {
        readonly [Prop in U]?: File[];
    };

3 test are failing because of this:

1. koa-body
   should receive `multipart` requests - fields on .body object:
2. koa-body
   should receive multiple fields and files via `multipart` on .body.files object:
3. koa-body
   can transform file names in multipart requests:

In the project there is a type ParseWithFormidableResult:

    import type { Fields, Files } from 'formidable';
    export type ParseWithFormidableResult = {
        fields: Fields;
        files: Files;
    };

My "dilemma" was fix the test (preserving the current behavior) or adapt the test to the new types (and break the current behavior).
Opted for the former (to keep the 6.x.y version)

The initial quick fix was to use something like the following:

    for (const key in processedFields) {
        const val = processedFields[key];
        if (Array.isArray(val) && val.length === 1) {
          // Cast to any to avoid TypeScript errors when modifying readonly properties
          (processedFields as any)[key] = val[0];
        }
    }

But in this way I was violating the type definition ParseWithFormidableResult because it is not possible to assign a scalar value to a property of type string[] the cast force it and make the compiler happy but it is not type safe and misleading for other devs

Hence opted to change the ParseWithFormidableResult too.


## Checklist

- [X] I have ensured my pull request is not behind the main or master branch of the original repository.
- [X] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [X] I have written a commit message that passes commitlint linting.
- [X] I have ensured that my code changes pass linting tests.
- [X] I have ensured that my code changes pass unit tests.
- [X] I have described my pull request and the reasons for code changes along with context if necessary.
